### PR TITLE
accomodate for new iterator in DOMTokenListPrototype

### DIFF
--- a/pz2-client.js
+++ b/pz2-client.js
@@ -4041,7 +4041,8 @@ function renderDetails(recordID) {
 								if (childPart === '#text') {
 									targetChild.appendChild(target.ownerDocument.createTextNode(child[childPart]));
 								}
-								else if (childPart[0] === '@') {
+								else if (childPart[0] === '@' && childPart[1] !== '@') {
+									// childs with names like '@@...' are not attributes!
 									targetChild.setAttribute(childPart.substr(1), child[childPart]);
 								}
 							}


### PR DESCRIPTION
Starting with Firefox 28, DOMTokenListPrototype defines an iterator
function called '@@iterator'. That breaks the assumption that all
child objects prefixed with '@' are designed attributes.

For now, we'll just skip operations on child objects prefixed with
"@@" (i.e. having a second '@' in string position #1).
